### PR TITLE
택배반납후 운송장을 작성한 사용자에게는 독촉 문자를 보내지 않음

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - 택배반납후 운송장을 작성한 사용자에게는 독촉 문자를 보내지 않음
 
 0.005     2015-10-13 17:49:20+09:00 Asia/Seoul
     - Remove `-` mark at recipient numbers (#8, volunteer#36)

--- a/bin/opencloset-cron-sms.pl
+++ b/bin/opencloset-cron-sms.pl
@@ -273,9 +273,9 @@ sub get_where {
     my $dtf = $DB->storage->datetime_parser;
 
     my $cond = {
-        status_id => 2,
+        status_id     => 2,
         return_method => undef,
-        -or       => [
+        -or           => [
             {
                 # 반납 희망일이 반납 예정일보다 이른 경우 반납 예정일을 기준으로 함
                 'target_date' => [

--- a/bin/opencloset-cron-sms.pl
+++ b/bin/opencloset-cron-sms.pl
@@ -274,6 +274,7 @@ sub get_where {
 
     my $cond = {
         status_id => 2,
+        return_method => undef,
         -or       => [
             {
                 # 반납 희망일이 반납 예정일보다 이른 경우 반납 예정일을 기준으로 함


### PR DESCRIPTION
https://github.com/opencloset/opencloset/issues/614
https://github.com/opencloset/opencloset/pull/622

와 관련이 있습니다.

택배반납후 운송장을 작성한 사용자에게는 독촉 문자를 보내지 않아야 합니다.

테스트를 해보지 않아서 확신할 수 없습니다.
