### PR TITLE
공휴일에는 D+1, D+2, D+3 문자를 발송하지 않음

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
     - 반납 당일 문자 메세지 내용 변경 (#22)
+    - 공휴일에는 D+1, D+2, D+3 문자를 발송하지 않음 (#24)
 
 0.010     2016-10-07 18:13:46+09:00 Asia/Seoul
     - order.ignore_sms 주문서는 SMS 를 보내지 않음 (#20)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,8 @@ my %WriteMakefileArgs = (
   "MIN_PERL_VERSION" => "5.008",
   "NAME" => "OpenCloset::Cron::SMS",
   "PREREQ_PM" => {
+    "Config::INI::Reader" => 0,
+    "Date::Holidays::KR" => 0,
     "DateTime" => 0,
     "FindBin" => 0,
     "Getopt::Long::Descriptive" => 0,
@@ -45,6 +47,8 @@ my %WriteMakefileArgs = (
 
 
 my %FallbackPrereqs = (
+  "Config::INI::Reader" => 0,
+  "Date::Holidays::KR" => 0,
   "DateTime" => 0,
   "ExtUtils::MakeMaker" => 0,
   "File::Spec" => 0,

--- a/bin/opencloset-cron-sms.pl
+++ b/bin/opencloset-cron-sms.pl
@@ -465,7 +465,7 @@ sub is_holiday {
     my $holidays = Date::Holidays::KR::holidays($year);
     return 1 if $holidays->{ $month . $day };
 
-    if ( my $ini = $CONF->{extra_holidays} ) {
+    if ( my $ini = $ENV{OPENCLOSET_EXTRA_HOLIDAYS} ) {
         my $extra_holidays = Config::INI::Reader->read_file($ini);
         return $extra_holidays->{$year}{ $month . $day };
     }

--- a/bin/opencloset-cron-sms.pl
+++ b/bin/opencloset-cron-sms.pl
@@ -9,6 +9,8 @@ use warnings;
 use FindBin qw( $Script );
 use Getopt::Long::Descriptive;
 
+use Config::INI::Reader;
+use Date::Holidays::KR ();
 use DateTime;
 use Try::Tiny;
 
@@ -155,6 +157,8 @@ my $worker3 = do {
             my $today = DateTime->today( time_zone => $TIMEZONE );
             return unless $today;
 
+            return if is_holiday($today);
+
             my $dt_start = $today->clone->subtract( days => 1 );
             return unless $dt_start;
 
@@ -199,6 +203,8 @@ my $worker4 = do {
             #
             my $dt_now = try { DateTime->now( time_zone => $TIMEZONE ); };
             return unless $dt_now;
+
+            return if is_holiday($dt_now);
 
             my $dt_start =
                 try { $dt_now->clone->truncate( to => 'day' )->subtract( days => 2 ); };
@@ -248,6 +254,8 @@ my $worker5 = do {
             #
             my $dt_now = try { DateTime->now( time_zone => $TIMEZONE ); };
             return unless $dt_now;
+
+            return if is_holiday($dt_now);
 
             my $dt_start =
                 try { $dt_now->clone->truncate( to => 'day' )->subtract( days => 3 ); };
@@ -445,4 +453,22 @@ sub get_where {
     my $attr = { order_by => { -asc => 'user_target_date' } };
 
     return ( $cond, $attr );
+}
+
+sub is_holiday {
+    my $date = shift;
+    return unless $date;
+
+    my $year     = $date->year;
+    my $month    = sprintf '%02d', $date->month;
+    my $day      = sprintf '%02d', $date->day;
+    my $holidays = Date::Holidays::KR::holidays($year);
+    return 1 if $holidays->{ $month . $day };
+
+    if ( my $ini = $CONF->{extra_holidays} ) {
+        my $extra_holidays = Config::INI::Reader->read_file($ini);
+        return $extra_holidays->{$year}{ $month . $day };
+    }
+
+    return;
 }

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,5 @@
+requires "Config::INI::Reader" => "0";
+requires "Date::Holidays::KR" => "0";
 requires "DateTime" => "0";
 requires "FindBin" => "0";
 requires "Getopt::Long::Descriptive" => "0";


### PR DESCRIPTION
#23

`opencloset/app.conf` 설정파일에 `extra_holidays` 를 기록한 `ini` 파일 경로가 주어져야 합니다.